### PR TITLE
feat: add prettier-plugin-tailwindcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "react-helmet-async": "1.3.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.21.8",
     "@commitlint/cli": "17.6.5",
     "@commitlint/config-conventional": "17.6.5",
-    "@babel/eslint-parser": "7.21.8",
     "commitizen": "4.3.0",
     "conventional-github-releaser": "3.1.5",
     "cz-conventional-changelog": "3.3.0",
@@ -58,6 +58,7 @@
     "gatsby-plugin-eslint": "4.0.4",
     "husky": "8.0.3",
     "prettier": "2.8.8",
+    "prettier-plugin-tailwindcss": "0.3.0",
     "standard-version": "9.5.0",
     "tailwindcss": "3.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13371,6 +13371,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-tailwindcss@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.3.0.tgz#8299b307c7f6467f52732265579ed9375be6c818"
+  integrity sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==
+
 prettier@2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
## Motivation:
把tailwind class排序的plugin加入模板，未來使用模板時就不需要額外安裝

## What this change does:
安裝套件 Automatic Class Sorting with Prettier
https://tailwindcss.com/blog/automatic-class-sorting-with-prettier